### PR TITLE
Add Volume Units

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ Gallons               | gallons, gal
 Quart                 | quart, qt
 Pint                  | pint, pt
 Fluid Ounces          | fluid ounces, floz
-Acre Inch             | acre inch, acre in, acre*in, acre*inch
-Acre Foot             | acre foot, acre ft, acre*ft, acre*foot
+Acre Inch             | acre inch, acre in, acre&ast;in, acre&ast;inch
+Acre Foot             | acre foot, acre ft, acre&ast;ft, acre&ast;foot
 
 ### Not currently supported
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ Micrograms            | micrograms, μg
 Milligrams            | milligrams, mg
 Grams                 | grams, g
 Killograms            | kilograms, kg
-Tonnes                | tonnes
+Tonnes                | tonnes, metric-ton
+Tons (US)             | ton, tons
 Ounces                | ounces, oz
 Pounds                | pounds, lb
 
@@ -153,10 +154,22 @@ Kilobars              | kilobars, kbar
 Pounds per Square Inch| psi
 Atmosphere            | atmosphere, at
 
+### Volume
+
+Unit                  | Names
+----------------------|---------------------------------------
+Litres                | litres, liters, L, l
+Millilitres           | millilitres, milliliters, ml, mL
+Gallons               | gallons, gal
+Quart                 | quart, qt
+Pint                  | pint, pt
+Fluid Ounces          | fluid ounces, floz
+Acre Inch             | acre inch, acre in, acre*in, acre*inch
+Acre Foot             | acre foot, acre ft, acre*ft, acre*foot
+
 ### Not currently supported
 
 - Area
-- Volume
 - Digital Storage
 - Data Transfer Rate
 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ Micrograms            | micrograms, μg
 Milligrams            | milligrams, mg
 Grams                 | grams, g
 Killograms            | kilograms, kg
-Tonnes                | tonnes, metric-ton
-Tons (US)             | ton, tons
+Tonnes                | tonnes, metric ton
+Tons (US)             | tons, ton
 Ounces                | ounces, oz
 Pounds                | pounds, lb
 
@@ -163,7 +163,7 @@ Millilitres           | millilitres, milliliters, ml, mL
 Gallons               | gallons, gal
 Quart                 | quart, qt
 Pint                  | pint, pt
-Fluid Ounces          | fluid ounces, floz
+Fluid Ounces          | fluid ounces, fl oz
 Acre Inch             | acre inch, acre in, acre&ast;in, acre&ast;inch
 Acre Foot             | acre foot, acre ft, acre&ast;ft, acre&ast;foot
 

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ Hours                 | hours, h
 
 Unit                  | Names
 ----------------------|---------------------------------------
-degrees Fahrenheit    | degrees Fahrenheit, deg F, celsius
-degrees Celsius       | degrees Celsius, deg C, fahrenheit
+degrees Fahrenheit    | degrees Fahrenheit, deg F, fahrenheit
+degrees Celsius       | degrees Celsius, deg C, celsius
 Kelvin                | kelvin
 
 ### Speed

--- a/addon/register-units.js
+++ b/addon/register-units.js
@@ -98,8 +98,8 @@ registerUnit(['atmosphere', 'at'], atmosphere);
 // Volume
 
 let liters = Unit.root();
-registerUnit(['litres', 'liters', 'L', 'l'], liters);
 registerUnit(['millilitres', 'milliliters', 'ml', 'mL'], Unit.scale(1e-3, liters));
+registerUnit(['litres', 'liters', 'L', 'l'], liters);
 
 let fluidOunces = Unit.scale(0.0295735, liters);
 registerUnit(['fluid ounces', 'fl oz'], fluidOunces);

--- a/addon/register-units.js
+++ b/addon/register-units.js
@@ -30,11 +30,12 @@ let grams = Unit.root();
 registerUnit(['milligrams', 'mg'], Unit.scale(1e-3, grams));
 registerUnit(['grams', 'g'], grams);
 registerUnit(['kilograms', 'kg'], Unit.scale(1e3, grams));
-registerUnit(['tonnes'], Unit.scale(1e6, grams));
+registerUnit(['tonnes', 'metric-ton'], Unit.scale(1e6, grams));
 
 let ounces = Unit.scale(28.349523125, grams);
 registerUnit(['ounces', 'oz'], ounces);
 registerUnit(['pounds', 'lb'], Unit.scale(16, ounces));
+registerUnit(['ton', 'tons'], Unit.scale(32e3, ounces));
 
 // Time
 

--- a/addon/register-units.js
+++ b/addon/register-units.js
@@ -93,3 +93,15 @@ registerUnit(['psi'], psi);
 
 let atmosphere = Unit.scale(101325, pascals);
 registerUnit(['atmosphere', 'at'], atmosphere);
+
+// Volume
+
+let liters = Unit.root();
+registerUnit(['litres', 'liters', 'L', 'l'], liters);
+registerUnit(['millilitres', 'milliliters', 'ml', 'mL'], Unit.scale(1e-3, liters));
+registerUnit(['gallons', 'gal'], Unit.scale(3.78541, liters));
+registerUnit(['quart', 'qt'], Unit.scale(0.946353, liters));
+registerUnit(['pint', 'pt'], Unit.scale(0.473176, liters));
+registerUnit(['fluid ounces', 'floz'], Unit.scale(0.0295735, liters));
+registerUnit(['acre inch', 'acre in', 'acre*in', 'acre*inch'], Unit.scale(102790.15461, liters));
+registerUnit(['acre foor', 'acre ft', 'acre*ft', 'acre*foot'], Unit.scale(1233480.22, liters));

--- a/addon/register-units.js
+++ b/addon/register-units.js
@@ -30,12 +30,12 @@ let grams = Unit.root();
 registerUnit(['milligrams', 'mg'], Unit.scale(1e-3, grams));
 registerUnit(['grams', 'g'], grams);
 registerUnit(['kilograms', 'kg'], Unit.scale(1e3, grams));
-registerUnit(['tonnes', 'metric-ton'], Unit.scale(1e6, grams));
+registerUnit(['tonnes', 'metric ton'], Unit.scale(1e6, grams));
 
 let ounces = Unit.scale(28.349523125, grams);
 registerUnit(['ounces', 'oz'], ounces);
 registerUnit(['pounds', 'lb'], Unit.scale(16, ounces));
-registerUnit(['ton', 'tons'], Unit.scale(32e3, ounces));
+registerUnit(['tons', 'ton'], Unit.scale(32e3, ounces));
 
 // Time
 
@@ -100,9 +100,13 @@ registerUnit(['atmosphere', 'at'], atmosphere);
 let liters = Unit.root();
 registerUnit(['litres', 'liters', 'L', 'l'], liters);
 registerUnit(['millilitres', 'milliliters', 'ml', 'mL'], Unit.scale(1e-3, liters));
-registerUnit(['gallons', 'gal'], Unit.scale(3.78541, liters));
-registerUnit(['quart', 'qt'], Unit.scale(0.946353, liters));
-registerUnit(['pint', 'pt'], Unit.scale(0.473176, liters));
-registerUnit(['fluid ounces', 'floz'], Unit.scale(0.0295735, liters));
-registerUnit(['acre inch', 'acre in', 'acre*in', 'acre*inch'], Unit.scale(102790.15461, liters));
-registerUnit(['acre foor', 'acre ft', 'acre*ft', 'acre*foot'], Unit.scale(1233480.22, liters));
+
+let fluidOunces = Unit.scale(0.0295735, liters);
+registerUnit(['fluid ounces', 'fl oz'], fluidOunces);
+registerUnit(['pint', 'pt'], Unit.scale(16, fluidOunces));
+registerUnit(['quart', 'qt'], Unit.scale(32, fluidOunces));
+registerUnit(['gallons', 'gal'], Unit.scale(128, fluidOunces));
+
+let gallons = Unit.scale(128, fluidOunces);
+registerUnit(['acre inch', 'acre in', 'acre*in', 'acre*inch'], Unit.scale(27154, gallons));
+registerUnit(['acre foot', 'acre ft', 'acre*ft', 'acre*foot'], Unit.scale(325851, gallons));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-convert-units",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"

--- a/tests/unit/convert-units-test.js
+++ b/tests/unit/convert-units-test.js
@@ -14,6 +14,8 @@ test(`converts scaled units correctly`, function(assert) {
 
   assert.conversionEqual(2, 'lb', 32, 'oz');
   assert.conversionEqual(2, 'lb', 0.90718474, 'kg');
+  assert.conversionEqual(1, 'ton', 2000, 'lb');
+  assert.conversionEqual(1, 'ton', 32000, 'oz');
 
   assert.conversionEqual(150000, 'ms', 2.5, 'minutes');
   assert.conversionEqual(1, 'l', 1000, 'mL');

--- a/tests/unit/convert-units-test.js
+++ b/tests/unit/convert-units-test.js
@@ -16,6 +16,13 @@ test(`converts scaled units correctly`, function(assert) {
   assert.conversionEqual(2, 'lb', 0.90718474, 'kg');
 
   assert.conversionEqual(150000, 'ms', 2.5, 'minutes');
+  assert.conversionEqual(1, 'l', 1000, 'mL');
+  assert.conversionAlmostEqual(1, 'l', 0.26417217685, 'gal');
+  assert.conversionAlmostEqual(1, 'l', 1.05668814913, 'qt');
+  assert.conversionAlmostEqual(1, 'l', 2.11337853145, 'pt');
+  assert.conversionAlmostEqual(1, 'l', 33.8140565032, 'floz');
+  assert.conversionAlmostEqual(1, 'acre*in', 27154.29890289294, 'gal');
+  assert.conversionAlmostEqual(1, 'acre*ft', 325851.15482867113, 'gal');
 
   // Floating point rounding errors
   assert.conversionAlmostEqual(1.3, 'ounces', 36.8543800625, 'g');

--- a/tests/unit/convert-units-test.js
+++ b/tests/unit/convert-units-test.js
@@ -19,12 +19,15 @@ test(`converts scaled units correctly`, function(assert) {
 
   assert.conversionEqual(150000, 'ms', 2.5, 'minutes');
   assert.conversionEqual(1, 'l', 1000, 'mL');
-  assert.conversionAlmostEqual(1, 'l', 0.26417217685, 'gal');
-  assert.conversionAlmostEqual(1, 'l', 1.05668814913, 'qt');
+  assert.conversionAlmostEqual(1, 'l', 0.26417231643, 'gal');
+  assert.conversionAlmostEqual(1, 'l', 1.05668926572, 'qt');
   assert.conversionAlmostEqual(1, 'l', 2.11337853145, 'pt');
-  assert.conversionAlmostEqual(1, 'l', 33.8140565032, 'floz');
-  assert.conversionAlmostEqual(1, 'acre*in', 27154.29890289294, 'gal');
-  assert.conversionAlmostEqual(1, 'acre*ft', 325851.15482867113, 'gal');
+  assert.conversionAlmostEqual(1, 'l', 33.8140565032, 'fl oz');
+  assert.conversionEqual(4, 'qt', 1, 'gal');
+  assert.conversionEqual(8, 'pt', 1, 'gal');
+  assert.conversionEqual(128, 'fl oz', 1, 'gal');
+  assert.conversionEqual(1, 'acre*in', 27154, 'gal');
+  assert.conversionEqual(1, 'acre*ft', 325851, 'gal');
 
   // Floating point rounding errors
   assert.conversionAlmostEqual(1.3, 'ounces', 36.8543800625, 'g');


### PR DESCRIPTION
Awesome Ember addon! Glad I ran across it. I've been doing lots of unit conversion for display on the server end and I decided enough was enough. This addon was the perfect fit for what I needed to do... after I added the units below.

A couple notes:
* Yes, Acre Inch is a real unit.
* Yes, Acre Foot is also a real unit.

They are generally used by farmers to determine water volume for rain. e.g. I got an inch of rain on my 200 acres == 200 acre*in

I added in the European version of spelling for Liters and Milliliters. The aliases I've come across are mainly the ones I've added. Lots of my metric users like seeing "L" for liters, US users like seeing "l" or "liters".

Let me know if there's anything else I need to do for this.